### PR TITLE
ci: Claudeのコードレビュー自動実行を無効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
プルリクエスト作成時に実行されるClaudeによるコードレビューのトリガーをからに変更し、手動実行に切り替えます。