### PR TITLE
ci: Claudeのコードレビュー自動実行を無効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,16 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, synchronize, labeled]
 
 jobs:
-  claude-review:
+  claude_review:
+    if: contains(github.event.pull_request.labels.*.name, 'claude-review')
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
プルリクエストに'claude-review'ラベルを付与することで、手動でレビューを実行できるようにします。