### PR TITLE
docs(readme): Fix Mermaid diagram syntax by quoting node text

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ MCP-Tx's unique power lies in its ability to treat **human operators as just ano
 flowchart LR
     subgraph "MCP-Tx Client (Orchestrator)"
         direction LR
-        A[call_tool('analyze_data')] --> B[call_tool('human_approval')] --> C[call_tool('send_report')]
+        A["call_tool('analyze_data')"] --> B["call_tool('human_approval')"] --> C["call_tool('send_report')"]
     end
 
     subgraph "MCP-Tx Servers"


### PR DESCRIPTION
Fixes a Mermaid syntax error in the README.md diagram. The parser failed because node text containing parentheses was not quoted.

This change encloses the problematic node text in double quotes, which is the standard way to handle special characters in Mermaid labels.